### PR TITLE
apk-builder: Always create 'src' directory

### DIFF
--- a/apk-builder/src/main.rs
+++ b/apk-builder/src/main.rs
@@ -198,6 +198,12 @@ fn build_directory(sdk_dir: &Path, crate_name: &str, libs: &HashMap<String, Path
         fs::mkdir_recursive(&libs_path, std::old_io::USER_RWX).unwrap();
     }
 
+    {
+        // Make sure that 'src' directory is creates
+        let src_path = build_directory.path().join("src");
+        fs::mkdir_recursive(&src_path, std::old_io::USER_RWX).unwrap();
+    }
+
     build_directory
 }
 


### PR DESCRIPTION
If this directory doesn't exist i'm getting error: "The following error occurred while executing this line: /tmp/android-rs-glue-rust-to-apk.fjU4MwJhUgKo/src does not exist".
