### PR TITLE
Fix sdk.dir written to local.properties to remove quotes.

### DIFF
--- a/apk-builder/src/main.rs
+++ b/apk-builder/src/main.rs
@@ -323,7 +323,7 @@ fn build_local_properties(sdk_dir: &Path) -> String {
     } else {
         env::current_dir().unwrap().join(sdk_dir)
     };
-    format!(r"sdk.dir={:?}", abs_dir)
+    format!(r"sdk.dir={}", abs_dir.to_str().unwrap())
 }
 
 fn build_project_properties() -> String {


### PR DESCRIPTION
This removes extra quotes introduced in

https://github.com/tomaka/android-rs-glue/commit/7f2ce2b2f7c06604af08b0a31629d4789621338e

Generated local.properties was:

sdk.dir="/android/sdk/directory"

should be:

sdk.dir=/android/sdk/drectory