### PR TITLE
Derive Clone, Copy for Event.

### DIFF
--- a/glue/src/lib.rs
+++ b/glue/src/lib.rs
@@ -85,7 +85,7 @@ struct Context {
 }
 
 /// An event triggered by the Android environment.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Event {
     EventUp,
     EventDown,
@@ -111,8 +111,6 @@ pub enum Event {
     Stop,
     Destroy,
 }
-
-impl Copy for Event {}
 
 #[cfg(not(target_os = "android"))]
 use this_platform_is_not_supported;


### PR DESCRIPTION
Building glue fails with rustc dev 2015-04-06:

glue/src/lib.rs:115:1: 115:23 error: the trait `core::clone::Clone` is not implemented for the type `Event` [E0277]
glue/src/lib.rs:115 impl Copy for Event {}