### PR TITLE
Fix failure to build with --features=assets_hack.

### DIFF
--- a/apk-builder/src/main.rs
+++ b/apk-builder/src/main.rs
@@ -120,7 +120,7 @@ fn copy_assets(build_path: &Path) {
     let cwd = env::current_dir().ok()
         .expect("Can not get current working directory!");
     let assets_path = cwd.join("assets");
-    if assets_path.exists() {
+    if let Ok(_) = File::open(assets_path.clone()) {
         fs::soft_link(&assets_path, &build_path.join("assets"))
             .ok().expect("Can not create symlink to assets");
     }


### PR DESCRIPTION
src/main.rs:123:20: 123:28 error: type `std::path::PathBuf` does not implement any method in scope named `exists`
src/main.rs:123     if assets_path.exists() {
                                   ^~~~~~~~
src/main.rs:123:20: 123:28 help: methods from traits can only be called if the trait is in scope; the following trait is implemented but not in scope, perhaps add a `use` for it:
src/main.rs:123:20: 123:28 help: candidate #1: use `std::fs::PathExt`
error: aborting due to previous error
Could not compile `apk-builder`.