### PR TITLE
Send more detailed information about motion events

### DIFF
--- a/glue/Cargo.toml
+++ b/glue/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "android_glue"
-version = "0.0.2"
+version = "0.1.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT"
 description = "Glue for the Android JNI"

--- a/glue/src/ffi.rs
+++ b/glue/src/ffi.rs
@@ -376,6 +376,7 @@ pub const AMOTION_EVENT_ACTION_MOVE: libc::int32_t = 2;
 pub const AMOTION_EVENT_ACTION_OUTSIDE: libc::int32_t = 4;
 pub const AMOTION_EVENT_ACTION_POINTER_DOWN: libc::int32_t = 5;
 pub const AMOTION_EVENT_ACTION_POINTER_INDEX_MASK: libc::int32_t = 65280;
+pub const AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT: libc::int32_t = 8;
 pub const AMOTION_EVENT_ACTION_POINTER_UP: libc::int32_t = 6;
 pub const AMOTION_EVENT_ACTION_SCROLL: libc::int32_t = 8;
 pub const AMOTION_EVENT_ACTION_UP: libc::int32_t = 1;


### PR DESCRIPTION
This adds the minimum amount of info needed to handle multi-touch gestures. It's likely that more information will be desired in the future, like the "toolType" field.

This is a breaking change.