### PR TITLE
I found some more bugs in my initial Android multi-touch code, now that I have a Servo branch with proper multi-touch gestures so I can really test it.

### DIFF
--- a/glue/src/lib.rs
+++ b/glue/src/lib.rs
@@ -83,6 +83,7 @@ struct Context {
     // A flag indicating that we should shutdown.
     shutdown:   AtomicBool,
     multitouch: Cell<bool>,
+    primary_pointer_id: Cell<i32>,
 }
 
 /// An event triggered by the Android environment.
@@ -203,6 +204,7 @@ pub fn android_main2<F>(app: *mut (), main_function: F)
         missedmax:  1024,
         shutdown:   AtomicBool::new(false),
         multitouch: Cell::new(false),
+        primary_pointer_id: Cell::new(0),
     };
     app.onAppCmd = commands_callback;
     app.onInputEvent = inputs_callback;
@@ -395,14 +397,15 @@ pub extern fn inputs_callback(_: *mut ffi::android_app, event: *const ffi::AInpu
                        >> ffi::AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT)
                       as libc::size_t;
 
+            let pointer_id = unsafe { ffi::AMotionEvent_getPointerId(event, idx) };
+            if action_code == ffi::AMOTION_EVENT_ACTION_DOWN {
+                context.primary_pointer_id.set(pointer_id);
+            }
             // When multi-touch is disabled, ignore motion events from additional pointers.
-            if idx > 0 && !context.multitouch.get() {
+            if !context.multitouch.get() && pointer_id != context.primary_pointer_id.get() {
                 return 0
             }
 
-            let pointer_id = unsafe {
-                ffi::AMotionEvent_getPointerId(event, idx)
-            };
             let x = unsafe { ffi::AMotionEvent_getX(event, idx) };
             let y = unsafe { ffi::AMotionEvent_getY(event, idx) };
 


### PR DESCRIPTION
The main fix here is that Android can bundle `ACTION_MOVE` for multiple pointers into a single event, so we may need to send more than one Rust event per Android event.