### PR TITLE
Prettier output

### DIFF
--- a/cargo-apk/Cargo.lock
+++ b/cargo-apk/Cargo.lock
@@ -3,7 +3,17 @@ name = "cargo-apk"
 version = "0.1.2"
 dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -12,10 +22,29 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "term"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "toml"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -8,4 +8,5 @@ repository = "https://github.com/tomaka/android-rs-glue/tree/master/cargo-apk"
 
 [dependencies]
 rustc-serialize = "0.3.19"
+term = "0.4.4"
 toml = "0.1.28"

--- a/cargo-apk/src/build.rs
+++ b/cargo-apk/src/build.rs
@@ -130,12 +130,12 @@ pub fn build(manifest_path: &Path, config: &Config) -> BuildResult {
         // Compiling the crate thanks to `cargo rustc`. We set the linker to `linker_exe`, a hacky
         // linker that will tweak the options passed to `gcc`.
         TermCmd::new("Compiling crate", "cargo").arg("rustc")
-            .arg("--verbose")
             .arg("--target").arg(build_target)
             .arg("--")
             .arg("-C").arg(format!("linker={}", android_artifacts_dir.join(if cfg!(target_os = "windows") { "linker_exe.exe" } else { "linker_exe" })
                                                                      .to_string_lossy()))
             .arg("--extern").arg(format!("cargo_apk_injected_glue={}", injected_glue_lib.to_string_lossy()))
+            .inherit_stdout()
             .env("CARGO_APK_GCC", gcc_path.as_os_str())
             .env("CARGO_APK_GCC_SYSROOT", gcc_sysroot.as_os_str())
             .env("CARGO_APK_NATIVE_APP_GLUE", build_target_dir.join("android_native_app_glue.o"))

--- a/cargo-apk/src/install.rs
+++ b/cargo-apk/src/install.rs
@@ -1,23 +1,17 @@
 use std::path::Path;
-use std::process::exit;
-use std::process::{Command, Stdio};
 
 use build;
 use config::Config;
+use termcmd::TermCmd;
 
 pub fn install(manifest_path: &Path, config: &Config) {
     let build_result = build::build(manifest_path, config);
 
     let adb = config.sdk_path.join("platform-tools/adb");
 
-    if Command::new(&adb)
+    TermCmd::new("Installing apk to the device", &adb)
         .arg("install")
         .arg("-r")      // TODO: let user choose
         .arg(&build_result.apk_path)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status().unwrap().code().unwrap() != 0
-    {
-        exit(1);
-    }
+        .execute();
 }

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -1,4 +1,5 @@
 extern crate rustc_serialize;
+extern crate term;
 extern crate toml;
 
 use std::env;
@@ -10,6 +11,7 @@ use std::process::Command;
 mod build;
 mod config;
 mod install;
+mod termcmd;
 
 fn main() {
     let command = env::args().skip(2).next();

--- a/cargo-apk/src/termcmd.rs
+++ b/cargo-apk/src/termcmd.rs
@@ -1,0 +1,91 @@
+//! This module provides features to pretty-print command execution in the tty.
+
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Command;
+use std::process::Stdio;
+use std::process::exit;
+use term;
+
+pub struct TermCmd {
+    label: String,
+    command: Command,
+    command_label: Vec<String>,
+}
+
+impl TermCmd {
+    #[inline]
+    pub fn new<L: Into<String>, S: AsRef<OsStr>>(label: L, program: S) -> TermCmd {
+        let command_label = program.as_ref().to_string_lossy().into_owned();
+
+        TermCmd {
+            label: label.into(),
+            command: {
+                let mut cmd = Command::new(program);
+                cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+                cmd
+            },
+            command_label: vec![command_label],
+        }
+    }
+
+    #[inline]
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut TermCmd {
+        self.command_label.push(arg.as_ref().to_string_lossy().into_owned());
+        self.command.arg(arg);
+        self
+    }
+
+    #[inline]
+    pub fn env<K: AsRef<OsStr>, V: AsRef<OsStr>>(&mut self, key: K, val: V) -> &mut TermCmd {
+        self.command.env(key, val);
+        self
+    }
+
+    #[inline]
+    pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut TermCmd {
+        self.command.current_dir(dir);
+        self
+    }
+
+    pub fn execute(&mut self) {
+        self.exec_stdout();
+    }
+
+    pub fn exec_stdout(&mut self) -> Vec<u8> {
+        let mut t = term::stdout().unwrap();
+
+        t.fg(term::color::BRIGHT_GREEN).unwrap();
+        t.attr(term::Attr::Bold).unwrap();
+        writeln!(t, "  Cargo-Apk: {}", self.label).unwrap();
+        t.reset().unwrap();
+
+        let output = self.command.output();
+        let success = match output.as_ref().map(|o| o.status) {
+            Ok(status) if status.success() => true,
+            _ => false,
+        };
+
+        if success {
+            return output.unwrap().stdout;
+        }
+
+        t.fg(term::color::RED).unwrap();
+        writeln!(t, "Error executing {:?}", self.command_label).unwrap();
+        match output.as_ref().map(|o| o.status.code()) {
+            Ok(Some(code)) => writeln!(t, "Status code {}", code).unwrap(),
+            Ok(None) => writeln!(t, "Interrupted").unwrap(),
+            Err(err) => writeln!(t, "{}", err).unwrap(),
+        }
+        t.reset().unwrap();
+
+        if let Ok(ref output) = output {
+            writeln!(t, "Stdout\n--------------------").unwrap();
+            t.write_all(&output.stdout).unwrap();
+            writeln!(t, "Stderr\n--------------------").unwrap();
+            t.write_all(&output.stderr).unwrap();
+        }
+
+        exit(1);    // TODO: meh, shouldn't exit here
+    }
+}


### PR DESCRIPTION
After this PR, when compiling the basic example:

>   Cargo-Apk: Compiling android_native_app_glue.c
  Cargo-Apk: Compiling injected-glue
  Cargo-Apk: Compiling injected-glue
  Cargo-Apk: Compiling glue_obj
  Cargo-Apk: Compiling crate
   Compiling android_glue_example v0.1.0 (file:///home/pierre/Projets/android-rs-glue/examples/basic)
  Cargo-Apk: Invoking ant
  Cargo-Apk: Installing apk to the device
