### PR TITLE
2 minor improvements

### DIFF
--- a/cargo-apk/injected-glue/ffi.rs
+++ b/cargo-apk/injected-glue/ffi.rs
@@ -324,6 +324,7 @@ pub type AInputEvent = ();
 extern { pub fn AInputEvent_getDeviceId(event: *const AInputEvent) -> i32; }
 extern { pub fn AInputEvent_getSource(event: *const AInputEvent) -> i32; }
 extern { pub fn AInputEvent_getType(event: *const AInputEvent) -> i32; }
+extern { pub fn AInputEvent_getKeyCode(event: *const AInputEvent) -> i32; }
 pub type AInputQueue = ();
 extern { pub fn AInputQueue_attachLooper(queue: *mut AInputQueue, looper: *mut ALooper, ident: c_int, callback: ALooper_callbackFunc, data: *mut c_void); }
 extern { pub fn AInputQueue_detachLooper(queue: *mut AInputQueue); }

--- a/cargo-apk/injected-glue/ffi.rs
+++ b/cargo-apk/injected-glue/ffi.rs
@@ -324,7 +324,6 @@ pub type AInputEvent = ();
 extern { pub fn AInputEvent_getDeviceId(event: *const AInputEvent) -> i32; }
 extern { pub fn AInputEvent_getSource(event: *const AInputEvent) -> i32; }
 extern { pub fn AInputEvent_getType(event: *const AInputEvent) -> i32; }
-extern { pub fn AInputEvent_getKeyCode(event: *const AInputEvent) -> i32; }
 pub type AInputQueue = ();
 extern { pub fn AInputQueue_attachLooper(queue: *mut AInputQueue, looper: *mut ALooper, ident: c_int, callback: ALooper_callbackFunc, data: *mut c_void); }
 extern { pub fn AInputQueue_detachLooper(queue: *mut AInputQueue); }

--- a/cargo-apk/injected-glue/lib.rs
+++ b/cargo-apk/injected-glue/lib.rs
@@ -83,8 +83,8 @@ struct Context {
 #[derive(Clone, Copy, Debug)]
 pub enum Event {
     EventMotion(Motion),
-    EventKeyUp,
-    EventKeyDown,
+    EventKeyUp(i32),
+    EventKeyDown(i32),
     InitWindow,
     SaveState,
     TermWindow,
@@ -375,10 +375,13 @@ pub extern fn inputs_callback(_: *mut ffi::android_app, event: *const ffi::AInpu
     let action_code = action & ffi::AMOTION_EVENT_ACTION_MASK;
 
     match etype {
-        ffi::AINPUT_EVENT_TYPE_KEY => match action_code {
-            ffi::AKEY_EVENT_ACTION_DOWN => { send_event(Event::EventKeyDown); },
-            ffi::AKEY_EVENT_ACTION_UP => send_event(Event::EventKeyUp),
-            _ => write_log(&format!("unknown input-event-type:{} action_code:{}", etype, action_code)),
+        ffi::AINPUT_EVENT_TYPE_KEY => {
+            let key_code = unsafe { ffi::AKeyEvent_getKeyCode(event) };
+            match action_code {
+                ffi::AKEY_EVENT_ACTION_DOWN => send_event(Event::EventKeyDown(key_code)),
+                ffi::AKEY_EVENT_ACTION_UP => send_event(Event::EventKeyUp(key_code)),
+                _ => write_log(&format!("unknown input-event-type:{} action_code:{}", etype, action_code)),
+            }
         },
         ffi::AINPUT_EVENT_TYPE_MOTION => {
             let motion_action = match action_code {

--- a/cargo-apk/src/config.rs
+++ b/cargo-apk/src/config.rs
@@ -34,6 +34,8 @@ pub struct Config {
     ///
     /// The assets can later be loaded with the runtime library.
     pub assets_path: Option<PathBuf>,
+    /// The external jar path;
+    pub jar_libs_path: Option<PathBuf>,
 
     /// Should we build in release mode?
     pub release: bool,
@@ -69,6 +71,11 @@ pub fn load(manifest_path: &Path) -> Config {
                     the $ANDROID_HOME environment variable.")
     };
 
+    let jar_libs_path = {
+        manifest_content.as_ref().and_then(|a| a.jar_libs_path.as_ref())
+            .map(|p| manifest_path.parent().unwrap().join(p))
+    };
+
     // For the moment some fields of the config are dummies.
     Config {
         sdk_path: Path::new(&sdk_path).to_owned(),
@@ -83,7 +90,7 @@ pub fn load(manifest_path: &Path) -> Config {
         android_version: manifest_content.as_ref().and_then(|a| a.android_version).unwrap_or(18),
         assets_path: manifest_content.as_ref().and_then(|a| a.assets.as_ref())
             .map(|p| manifest_path.parent().unwrap().join(p)),
-
+        jar_libs_path: jar_libs_path,
         release: false,
     }
 }
@@ -104,5 +111,6 @@ struct TomlAndroid {
     package_name: Option<String>,
     label: Option<String>,
     assets: Option<String>,
+    jar_libs_path: Option<String>,
     android_version: Option<u32>,
 }

--- a/glue/src/lib.rs
+++ b/glue/src/lib.rs
@@ -18,8 +18,8 @@ use std::sync::mpsc::Sender;
 #[derive(Clone, Copy, Debug)]
 pub enum Event {
     EventMotion(Motion),
-    EventKeyUp,
-    EventKeyDown,
+    EventKeyUp(i32),
+    EventKeyDown(i32),
     InitWindow,
     SaveState,
     TermWindow,


### PR DESCRIPTION
this pull request includes two minor improvements:

- when developer puts external java jar libs inside of `android/jars`, the build.rs picked them up and put to `target/android-artifacts/build/libs`
- when the project contains other dylibs apart from `libmain.so`, app fails to loadLibrary("libmain.so"). by putting this line at the first, it works. I'm not quite sure the underlying mechanism, so it might be a problem of my old HW phone.