### PR TITLE
Expose option for multiple build targets

### DIFF
--- a/cargo-apk/Cargo.lock
+++ b/cargo-apk/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-apk"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -48,3 +48,10 @@ name = "winapi-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[metadata]
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
+"checksum term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3deff8a2b3b6607d6d7cc32ac25c0b33709453ca9cceac006caac51e963cf94a"
+"checksum toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "fcd27a04ca509aff336ba5eb2abc58d456f52c4ff64d9724d88acb85ead560b6"
+"checksum winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4dfaaa8fbdaa618fa6914b59b2769d690dd7521920a18d84b42d254678dd5fd4"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/cargo-apk/src/build.rs
+++ b/cargo-apk/src/build.rs
@@ -104,8 +104,18 @@ pub fn build(manifest_path: &Path, config: &Config) -> BuildResult {
                        // TODO: mips64
                        else { panic!("Unknown or incompatible build target: {}", build_target) };
 
+            // Looks like the tools don't always share the prefix of the target arch
+            // Just a macos issue?
+            let tool_prefix = if build_target.starts_with("arm") { "arm-linux-androideabi" }
+                       else if build_target.starts_with("aarch64") { "aarch64-linux-android" }
+                       else if build_target.starts_with("i") { "i686-linux-android" }
+                       else if build_target.starts_with("x86_64") { "x86_64-linux-android" }
+                       else if build_target.starts_with("mipsel") { "mipsel-linux-android" }
+                       // TODO: mips64
+                       else { panic!("Unknown or incompatible build target: {}", build_target) };
+
             let base = config.ndk_path.join(format!("toolchains/{}-4.9/prebuilt/{}-x86_64", target_arch, host_os));
-            (base.join(format!("bin/{}-gcc", target_arch)), base.join(format!("bin/{}-ar", target_arch)))
+            (base.join(format!("bin/{}-gcc", tool_prefix)), base.join(format!("bin/{}-ar", tool_prefix)))
         };
 
         let gcc_sysroot = {
@@ -402,7 +412,7 @@ fn build_manifest(path: &Path, config: &Config) {
         format!("0x{:04}{:04}", 2, 0), //TODO: get opengl es version from somewhere
         application_attrs,
         activity_attrs
-    );
+    ).unwrap();
 }
 
 fn build_assets(path: &Path, config: &Config) {

--- a/cargo-apk/src/build.rs
+++ b/cargo-apk/src/build.rs
@@ -1,5 +1,5 @@
 use std::os;
-use std::collections::HashSet;
+use std::collections::{HashSet, HashMap};
 use std::env;
 use std::fs;
 use std::fs::File;
@@ -86,6 +86,8 @@ pub fn build(manifest_path: &Path, config: &Config) -> BuildResult {
     };
     build_android_artifacts_dir(&android_artifacts_dir, &config);
 
+    let mut abi_libs: HashMap<&str, Vec<String>> = HashMap::new();
+
     for build_target in config.build_targets.iter() {
         let build_target_dir = android_artifacts_dir.join(build_target);
 
@@ -129,6 +131,16 @@ pub fn build(manifest_path: &Path, config: &Config) -> BuildResult {
             config.ndk_path.join(format!("platforms/android-{v}/arch-{a}",
                                          v = config.android_version, a = arch))
         };
+
+        // Create android cpu abi name
+        let abi = if build_target.starts_with("arm") { "armeabi" }
+                  // TODO: armeabi-v7a
+                  else if build_target.starts_with("aarch64") { "arm64-v8a" }
+                  else if build_target.starts_with("i") { "x86" }
+                  else if build_target.starts_with("x86_64") { "x86_64" }
+                  else if build_target.starts_with("mips") { "mips" }
+                  // TODO: mips64
+                  else { panic!("Unknown or incompatible build target: {}", build_target) };
 
         // Compiling android_native_app_glue.c
         TermCmd::new("Compiling android_native_app_glue.c", &gcc_path)
@@ -174,18 +186,7 @@ pub fn build(manifest_path: &Path, config: &Config) -> BuildResult {
             .execute();
 
         // Directory where we will put the native libraries for ant to pick them up.
-        let native_libraries_dir = {
-            let abi = if build_target.starts_with("arm") { "armeabi" }
-                      // TODO: armeabi-v7a
-                      else if build_target.starts_with("aarch64") { "arm64-v8a" }
-                      else if build_target.starts_with("i") { "x86" }
-                      else if build_target.starts_with("x86_64") { "x86_64" }
-                      else if build_target.starts_with("mips") { "mips" }
-                      // TODO: mips64
-                      else { panic!("Unknown or incompatible build target: {}", build_target) };
-
-            android_artifacts_dir.join(format!("build/libs/{}", abi))
-        };
+        let native_libraries_dir = android_artifacts_dir.join(format!("build/libs/{}", abi));
 
         if fs::metadata(&native_libraries_dir).is_err() {
             fs::DirBuilder::new().recursive(true).create(&native_libraries_dir).unwrap();
@@ -261,11 +262,11 @@ pub fn build(manifest_path: &Path, config: &Config) -> BuildResult {
             shared_objects_to_load
         };
 
-        // Write the Java source
-        // FIXME: duh, the file will be replaced every time, so this only works with one target
-        build_java_src(&android_artifacts_dir, &config,
-                       shared_objects_to_load.iter().map(|s| &**s));
+        abi_libs.insert(abi, shared_objects_to_load);
     }
+
+    // Write the Java source
+    build_java_src(&android_artifacts_dir, &config, &abi_libs);
 
     // Invoking `ant` from within `android-artifacts` in order to compile the project.
     TermCmd::new("Invoking ant", &config.ant_command)
@@ -327,8 +328,7 @@ fn build_linker(path: &Path) {
     assert!(fs::metadata(&exe_file).is_ok());
 }
 
-fn build_java_src<'a, I>(path: &Path, config: &Config, libs: I)
-    where I: Iterator<Item = &'a str>
+fn build_java_src(path: &Path, config: &Config, abi_libs: &HashMap<&str, Vec<String>>)
 {
     let file = path.join("build/src/rust").join(config.project_name.replace("-", "_"))
                    .join("MainActivity.java");
@@ -337,18 +337,52 @@ fn build_java_src<'a, I>(path: &Path, config: &Config, libs: I)
     let mut file = File::create(&file).unwrap();
 
     let mut libs_string = String::new();
-    for name in libs {
-        // Strip off the 'lib' prefix and ".so" suffix.
-        let line = format!("        System.loadLibrary(\"{}\");\n",
-            name.trim_left_matches("lib").trim_right_matches(".so"));
-        libs_string.push_str(&*line);
+
+    for (abi, libs) in abi_libs {
+
+        libs_string.push_str(format!("            if (abi.equals(\"{}\")) {{\n",abi).as_str());
+        libs_string.push_str(format!("                matched_an_abi = true;\n").as_str());
+
+        for name in libs {
+            // Strip off the 'lib' prefix and ".so" suffix.
+            let line = format!("                System.loadLibrary(\"{}\");\n",
+                name.trim_left_matches("lib").trim_right_matches(".so"));
+            libs_string.push_str(&*line);
+        }
+
+        libs_string.push_str(format!("                break;\n").as_str());
+        libs_string.push_str(format!("            }}\n").as_str());
     }
 
     write!(file, r#"package rust.{package_name};
 
+import java.lang.UnsupportedOperationException;
+import android.os.Build;
+import android.util.Log;
+
 public class MainActivity extends android.app.NativeActivity {{
+
     static {{
-        {libs}
+
+        String[] supported_abis;
+
+        try {{
+            supported_abis = (String[]) Build.class.getField("SUPPORTED_ABIS").get(null);
+        }} catch (Exception e) {{
+            // Assume that this is an older phone; use backwards-compatible targets.
+            supported_abis = new String[]{{Build.CPU_ABI, Build.CPU_ABI2}};
+        }}
+
+        boolean matched_an_abi = false;
+
+        for (String abi : supported_abis) {{
+{libs}
+        }}
+
+        if (!matched_an_abi) {{
+            throw new UnsupportedOperationException("Could not find a native abi target to load");
+        }}
+
     }}
 }}"#, libs = libs_string, package_name = config.project_name.replace("-", "_")).unwrap();
 }
@@ -458,6 +492,7 @@ fn build_build_xml(path: &Path, config: &Config) {
     <loadproperties srcFile="project.properties" />
     <import file="custom_rules.xml" optional="true" />
     <import file="${{sdk.dir}}/tools/ant/build.xml" />
+
 </project>
 "#, project_name = config.project_name).unwrap()
 }

--- a/cargo-apk/src/config.rs
+++ b/cargo-apk/src/config.rs
@@ -101,7 +101,8 @@ pub fn load(manifest_path: &Path) -> Config {
         package_label: manifest_content.as_ref().and_then(|a| a.label.clone())
                                        .unwrap_or_else(|| package_name.clone()),
         package_icon: manifest_content.as_ref().and_then(|a| a.icon.clone()),
-        build_targets: vec!["arm-linux-androideabi".to_owned()],
+        build_targets: manifest_content.as_ref().and_then(|a| a.build_targets.clone())
+                                       .unwrap_or(vec!["arm-linux-androideabi".to_owned()]),
         android_version: manifest_content.as_ref().and_then(|a| a.android_version).unwrap_or(18),
         assets_path: manifest_content.as_ref().and_then(|a| a.assets.as_ref())
             .map(|p| manifest_path.parent().unwrap().join(p)),
@@ -149,4 +150,5 @@ struct TomlAndroid {
     fullscreen: Option<bool>,
     application_attributes: Option<BTreeMap<String, String>>,
     activity_attributes: Option<BTreeMap<String, String>>,
+    build_targets: Option<Vec<String>>,
 }


### PR DESCRIPTION
I use genymotion as my android emulator, which runs x86 code and so needed the 'i686-linux-android' target. After realising I had to change the cargo-apk's source to build this I decided to submit a patch.

Possibly there was a reason this wasn't already exposed? 