### PR TITLE
Adds --bin flag.

### DIFF
--- a/cargo-apk/src/build.rs
+++ b/cargo-apk/src/build.rs
@@ -40,6 +40,9 @@ pub fn build(manifest_path: &Path, config: &Config) -> BuildResult {
     pub trait AddAntReleaseFlag {
         fn add_ant_release_flag(&mut self, config: &Config) -> &mut Self;
     }
+    pub trait AddCargoTargetFlag {
+        fn add_cargo_target_flag(&mut self, config: &Config) -> &mut Self;
+    }
 
     impl AddGccReleaseFlag for TermCmd {
         fn add_gcc_release_flag(&mut self, config: &Config) -> &mut TermCmd {
@@ -75,6 +78,15 @@ pub fn build(manifest_path: &Path, config: &Config) -> BuildResult {
                 self.arg("release")
             } else {
                 self.arg("debug")
+            }
+        }
+    }
+    impl AddCargoTargetFlag for TermCmd {
+        fn add_cargo_target_flag(&mut self, config: &Config) -> &mut TermCmd {
+            if let Some(ref target) = config.target {
+                self.arg("--bin").arg(target)
+            } else {
+                self
             }
         }
     }
@@ -196,6 +208,7 @@ pub fn build(manifest_path: &Path, config: &Config) -> BuildResult {
         // linker that will tweak the options passed to `gcc`.
         TermCmd::new("Compiling crate", "cargo").arg("rustc")
             .arg("--target").arg(build_target)
+            .add_cargo_target_flag(config)
             .add_cargo_release_flag(config)
             .arg("--")
             .arg("-C").arg(format!("linker={}", android_artifacts_dir.join(if cfg!(target_os = "windows") { "linker_exe.exe" } else { "linker_exe" })

--- a/cargo-apk/src/config.rs
+++ b/cargo-apk/src/config.rs
@@ -52,11 +52,14 @@ pub struct Config {
     /// Should this app be in fullscreen mode (hides the title bar)?
     pub fullscreen: bool,
 
-    // Appends this string to the application attributes in the AndroidManifest.xml
+    /// Appends this string to the application attributes in the AndroidManifest.xml
     pub application_attributes: Option<String>,
 
-    // Appends this string to the activity attributes in the AndroidManifest.xml
+    /// Appends this string to the activity attributes in the AndroidManifest.xml
     pub activity_attributes: Option<String>,
+
+    /// The name of the executable to compile.
+    pub target: Option<String>,
 }
 
 pub fn load(manifest_path: &Path) -> Config {
@@ -111,7 +114,8 @@ pub fn load(manifest_path: &Path) -> Config {
         release: false,
         fullscreen: manifest_content.as_ref().and_then(|a| a.fullscreen.clone()).unwrap_or(false),
         application_attributes: manifest_content.as_ref().and_then(|a| map_to_string(a.application_attributes.clone())),
-        activity_attributes: manifest_content.as_ref().and_then(|a| map_to_string(a.activity_attributes.clone()))
+        activity_attributes: manifest_content.as_ref().and_then(|a| map_to_string(a.activity_attributes.clone())),
+        target: None,
     }
 }
 

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -20,7 +20,10 @@ fn main() {
 
     // Fetching the configuration for the build.
     let mut config = config::load(&current_manifest);
-    config.release = env::args().any(|s| &s[..] == "--release" );
+    config.release = env::args().any(|s| &s[..] == "--release");
+    if let Some(target_arg_index) = env::args().position(|s| &s[..] == "--bin") {
+        config.target = env::args().skip(target_arg_index + 1).next();
+    }
 
     if command.as_ref().map(|s| &s[..]) == Some("install") {
         install::install(&current_manifest, &config);


### PR DESCRIPTION
This allows closing #118.

Where before having the hierarchy:

```
crate/
  src/
    bin/
      main.rs
      other.rs
    lib.rs
```

made it impossible to use `cargo apk`, it is now possible to specify which `bin` should be built via the `--bin` flag, for example, `cargo apk --bin main`.