### PR TITLE
Add a Dockerfile for easier development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: rust
-sudo: false
+sudo: required
+
+services:
+    - docker
 
 script:
     - cargo build --verbose --manifest-path glue/Cargo.toml
     - cargo build --verbose --manifest-path cargo-apk/Cargo.toml
+    - docker build -t cargo-apk .
+    - docker run --rm -v `pwd`:/root/src -w /root/src/examples/basic cargo-apk cargo apk
+    - docker run --rm -v `pwd`:/root/src -w /root/src/examples/use_assets cargo-apk cargo apk
+    - docker run --rm -v `pwd`:/root/src -w /root/src/examples/use_icon cargo-apk cargo apk
 
 after_success: 
     - |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:xenial
+
+RUN apt-get update
+RUN apt-get install -yq sudo curl wget git file g++ cmake pkg-config \
+                        libasound2-dev bison flex unzip ant openjdk-8-jdk \
+                        lib32stdc++6 lib32z1
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH /root/.cargo/bin:$PATH
+RUN rustup default nightly
+RUN rustup target add arm-linux-androideabi
+
+RUN mkdir /root/cargo-apk
+COPY . /root/cargo-apk
+RUN cargo install --path /root/cargo-apk/cargo-apk
+RUN rm -rf /root/cargo-apk
+
+ENV ANDROID_HOME /usr/local/android-sdk-linux
+RUN cd /usr/local && \
+    wget -q https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz && \
+    tar -xzf android-sdk_r24.4.1-linux.tgz && \
+    rm android-sdk_r24.4.1-linux.tgz
+RUN echo y | ${ANDROID_HOME}/tools/android update sdk --no-ui --all --filter platform-tools,android-18,build-tools-23.0.3
+ENV PATH $PATH:${ANDROID_HOME}/tools:$ANDROID_HOME/platform-tools
+
+RUN cd /usr/local && \
+    wget -q http://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip && \
+    unzip -q android-ndk-r12b-linux-x86_64.zip && \
+    rm android-ndk-r12b-linux-x86_64.zip
+
+ENV NDK_HOME /usr/local/android-ndk-r12b
+
+RUN mkdir /root/src
+WORKDIR /root/src

--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
 # Usage
 
-## Setting up your environment
+## With docker
+
+The easiest way to compile for Android is to use [docker](https://www.docker.com/) and the
+[tomaka/android-rs-glue](https://hub.docker.com/r/tomaka/android-rs-glue/) image.
+
+In order to build an APK, simply do this:
+
+```
+docker run --rm -v <path-to-local-directory-with-Cargo.toml>:/root/src tomaka/android-rs-glue cargo apk
+```
+
+For example if you're on Linux and you want to compile the project in the current working
+directory.
+
+```
+docker run --rm -v `pwd`:/root/src -w /root/src tomaka/android-rs-glue cargo apk
+```
+
+`cargo apk` only compiles the Cargo.toml of the current working directory, so we have to set it
+before running the command. In the future `cargo apk` should be able to accept the
+`--manifest-path` option. Do not mount a volume on `/root` or you will erase the local
+installation of Cargo.
+
+After the build is finished, you should an Android package in `target/android-artifacts/build/bin`.
+
+## Manual usage
+
+### Setting up your environment
 
 Before you can compile for Android, you need to setup your environment. This needs to be done only once per system.
 
@@ -16,13 +43,13 @@ Before you can compile for Android, you need to setup your environment. This nee
  - Install `cargo-apk` with `cargo install cargo-apk`.
  - Be sure to set `NDK_HOME` to the path of your NDK and `ANDROID_HOME` to the path of your SDK.
 
-## Compiling
+### Compiling
 
 In the project root for your Android crate, run `cargo apk`.
 
 This will build an Android package in `target/android-artifacts/build/bin`.
 
-## Testing on an Android emulator
+### Testing on an Android emulator
 
 Start the emulator, then run:
 
@@ -32,7 +59,7 @@ adb install -r target/your_crate
 
 This will install your application on the emulator.
 
-## Interfacing with Android
+# Interfacing with Android
 
 An application is not very useful if it doesn't have access to the screen, the user inputs, etc.
 

--- a/examples/use_assets/Cargo.lock
+++ b/examples/use_assets/Cargo.lock
@@ -1,5 +1,5 @@
 [root]
-name = "android_glue_example"
+name = "android_glue_assets_example"
 version = "0.1.0"
 dependencies = [
  "android_glue 0.2.1",

--- a/examples/use_icon/Cargo.lock
+++ b/examples/use_icon/Cargo.lock
@@ -1,5 +1,5 @@
 [root]
-name = "android_glue_example"
+name = "android_glue_icon_example"
 version = "0.1.0"
 dependencies = [
  "android_glue 0.2.1",


### PR DESCRIPTION
Copied from https://github.com/tomaka/rust-android-docker

I created this PR to let hub.docker.com build the image, which is going to go much faster than if I do it with my aweful Internet connection.

To do before merging:
- [x] Update the README to show usage.
- [x] Compile cargo-apk from the github repo instead of the published version.
