### PR TITLE
Add gles version config

### DIFF
--- a/cargo-apk/src/build.rs
+++ b/cargo-apk/src/build.rs
@@ -436,7 +436,7 @@ fn build_manifest(path: &Path, config: &Config) {
         android:versionCode="1"
         android:versionName="1.0">
 
-    <uses-sdk android:minSdkVersion="9" />
+    <uses-sdk android:minSdkVersion="{minSdkVersion}" />
 
     <uses-feature android:glEsVersion="{glEsVersion}" android:required="true"></uses-feature>
     <uses-permission android:name="android.permission.INTERNET" />
@@ -456,6 +456,7 @@ fn build_manifest(path: &Path, config: &Config) {
 <!-- END_INCLUDE(manifest) -->
 "#,
         package = config.package_name.replace("-", "_"),
+        minSdkVersion = config.android_version,
         glEsVersion = format!("0x{:04}{:04}", config.opengles_version_major, config.opengles_version_minor),
         application_attrs = application_attrs,
         activity_attrs = activity_attrs

--- a/cargo-apk/src/build.rs
+++ b/cargo-apk/src/build.rs
@@ -432,19 +432,19 @@ fn build_manifest(path: &Path, config: &Config) {
         file, r#"<?xml version="1.0" encoding="utf-8"?>
 <!-- BEGIN_INCLUDE(manifest) -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-        package="{0}"
+        package="{package}"
         android:versionCode="1"
         android:versionName="1.0">
 
     <uses-sdk android:minSdkVersion="9" />
 
-    <uses-feature android:glEsVersion="{1}" android:required="true"></uses-feature>
+    <uses-feature android:glEsVersion="{glEsVersion}" android:required="true"></uses-feature>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
-    <application {2} >
-        <activity {3} >
+    <application {application_attrs} >
+        <activity {activity_attrs} >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -455,10 +455,10 @@ fn build_manifest(path: &Path, config: &Config) {
 </manifest>
 <!-- END_INCLUDE(manifest) -->
 "#,
-        config.package_name.replace("-", "_"),
-        format!("0x{:04}{:04}", 2, 0), //TODO: get opengl es version from somewhere
-        application_attrs,
-        activity_attrs
+        package = config.package_name.replace("-", "_"),
+        glEsVersion = format!("0x{:04}{:04}", config.opengles_version_major, config.opengles_version_minor),
+        application_attrs = application_attrs,
+        activity_attrs = activity_attrs
     ).unwrap();
 }
 

--- a/cargo-apk/src/config.rs
+++ b/cargo-apk/src/config.rs
@@ -60,6 +60,12 @@ pub struct Config {
 
     /// The name of the executable to compile.
     pub target: Option<String>,
+
+    /// The OpenGL ES major version in the AndroidManifest.xml
+    pub opengles_version_major: u8,
+
+    /// The OpenGL ES minor version in the AndroidManifest.xml
+    pub opengles_version_minor: u8,
 }
 
 pub fn load(manifest_path: &Path) -> Config {
@@ -116,6 +122,8 @@ pub fn load(manifest_path: &Path) -> Config {
         application_attributes: manifest_content.as_ref().and_then(|a| map_to_string(a.application_attributes.clone())),
         activity_attributes: manifest_content.as_ref().and_then(|a| map_to_string(a.activity_attributes.clone())),
         target: None,
+        opengles_version_major: manifest_content.as_ref().and_then(|a| a.opengles_version_major).unwrap_or(2),
+        opengles_version_minor: manifest_content.as_ref().and_then(|a| a.opengles_version_minor).unwrap_or(0),
     }
 }
 
@@ -155,4 +163,6 @@ struct TomlAndroid {
     application_attributes: Option<BTreeMap<String, String>>,
     activity_attributes: Option<BTreeMap<String, String>>,
     build_targets: Option<Vec<String>>,
+    opengles_version_major: Option<u8>,
+    opengles_version_minor: Option<u8>,
 }


### PR DESCRIPTION
Adds the ability to configure the OpenGL ES version used in AndroidManifest.xml. I also updated the `minSdkVersion` attribute to use the configured version, rather than the static value of '9'.