### PR TITLE
Add API to allow receiving sync events from the polling thread.

### DIFF
--- a/examples/basic/Cargo.lock
+++ b/examples/basic/Cargo.lock
@@ -2,10 +2,10 @@
 name = "android_glue_example"
 version = "0.1.0"
 dependencies = [
- "android_glue 0.2.2",
+ "android_glue 0.2.3",
 ]
 
 [[package]]
 name = "android_glue"
-version = "0.2.2"
+version = "0.2.3"
 

--- a/examples/use_assets/Cargo.lock
+++ b/examples/use_assets/Cargo.lock
@@ -2,10 +2,10 @@
 name = "android_glue_assets_example"
 version = "0.1.0"
 dependencies = [
- "android_glue 0.2.2",
+ "android_glue 0.2.3",
 ]
 
 [[package]]
 name = "android_glue"
-version = "0.2.2"
+version = "0.2.3"
 

--- a/examples/use_icon/Cargo.lock
+++ b/examples/use_icon/Cargo.lock
@@ -2,10 +2,10 @@
 name = "android_glue_icon_example"
 version = "0.1.0"
 dependencies = [
- "android_glue 0.2.2",
+ "android_glue 0.2.3",
 ]
 
 [[package]]
 name = "android_glue"
-version = "0.2.2"
+version = "0.2.3"
 

--- a/glue/Cargo.toml
+++ b/glue/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "android_glue"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT"
 description = "Glue for the Android JNI"


### PR DESCRIPTION
Hello, this PR adds an API to allow receiving synchronous events from the Android polling thread. 

Currently all events are async and there isn't a clean way to handle some life time events in the correct order in complex scenarios with multiple threads & render resources.  For example the Oculus VR Mobile SDK requires dropping some GL resources and leaving Activity VR mode before EGLSurface is destroyed (in glutin) and the app goes to background.

With the channel approach the order of the multiple event handlers (e.g.: Glutin, VR Module) is not guaranteed. Sometimes Glutin releases the EGLSurface first  and sometines later. There is an additional complexity in my scenario, some OculusVR resources must be dropped/paused in a separate thread (VR thread is a different one from the main EGL render thread & from the event loop). So I need to block the event handler thread until resources are freed in the correct thread to prevent collisions (e.g.  Glutin dropping the EGLSurface at the same time). Channels don't allow that kind of blocking now.

With the SyncEventHandler API I was able to fix both issues: I can guarantee the order of the calls and block the event loop temporary if required to avoid collisions with other senders/event handlers. The life cycle of OculusVR works like a charm this way.

