### PR TITLE
Added ability to customise gradle command.

### DIFF
--- a/cargo-apk/Cargo.lock
+++ b/cargo-apk/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-apk"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cargo 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cargo-apk/src/config.rs
+++ b/cargo-apk/src/config.rs
@@ -107,9 +107,8 @@ pub fn load(workspace: &Workspace, flag_package: &Option<String>) -> Result<Andr
         (package_name, decoded.metadata.and_then(|m| m.android))
     };
 
-    // Determine the gradle command from the manifest (can be set to gradle.bat
-    // on windows)
-    let gradle_command = manifest_content.as_ref().and_then(|m| m.gradle_command.clone());
+    // Determine the gradle command from the env variables
+    let gradle_command = env::var("CARGO_APK_GRADLE_COMMAND").ok();
 
     let ndk_path = env::var("NDK_HOME").expect("Please set the path to the Android NDK with the \
                                                 $NDK_HOME environment variable.");

--- a/cargo-apk/src/config.rs
+++ b/cargo-apk/src/config.rs
@@ -108,8 +108,7 @@ pub fn load(workspace: &Workspace, flag_package: &Option<String>) -> Result<Andr
     };
 
     // Determine the gradle command from the env variables
-    let gradle_command = env::var("CARGO_APK_GRADLE_COMMAND").ok();
-
+    let gradle_command = env::var("CARGO_APK_GRADLE_COMMAND").ok().unwrap_or("gradle".to_owned());
     let ndk_path = env::var("NDK_HOME").expect("Please set the path to the Android NDK with the \
                                                 $NDK_HOME environment variable.");
 
@@ -154,7 +153,7 @@ pub fn load(workspace: &Workspace, flag_package: &Option<String>) -> Result<Andr
     Ok(AndroidConfig {
         sdk_path: Path::new(&sdk_path).to_owned(),
         ndk_path: Path::new(&ndk_path).to_owned(),
-        gradle_command: gradle_command.unwrap_or("gradle".to_owned()),
+        gradle_command: gradle_command,
         package_name: manifest_content.as_ref().and_then(|a| a.package_name.clone())
                                        .unwrap_or_else(|| format!("rust.{}", package_name)),
         project_name: package_name.clone(),

--- a/cargo-apk/src/ops/build.rs
+++ b/cargo-apk/src/ops/build.rs
@@ -30,8 +30,9 @@ pub fn build(workspace: &Workspace, config: &AndroidConfig, options: &Options)
         _ => {
             return Err(CargoError::from(r#"Could not execute `gradle`. Did you
                 install it? (If already installed on windows with `gradle.bat`
-                in your classpath, you must customise the gradle command with
-                the gradle_command field under package.metadata.android)."#));
+                in your path, you must customise the gradle command to
+                `gradle.bat` with the CARGO_APK_GRADLE_COMMAND environment
+                variable)."#));
         }
     }
 

--- a/cargo-apk/src/ops/build.rs
+++ b/cargo-apk/src/ops/build.rs
@@ -28,7 +28,10 @@ pub fn build(workspace: &Workspace, config: &AndroidConfig, options: &Options)
     match Command::new(&config.gradle_command).arg("-v").stdout(Stdio::null()).status() {
         Ok(s) if s.success() => (),
         _ => {
-            return Err(CargoError::from("Could not execute `gradle`. Did you install it?"));
+            return Err(CargoError::from(r#"Could not execute `gradle`. Did you
+                install it? (If already installed on windows with `gradle.bat`
+                in your classpath, you must customise the gradle command with
+                the gradle_command field under package.metadata.android)."#));
         }
     }
 


### PR DESCRIPTION
On windows, a new gradle install had the gradle command in a 'gradle.bat' file. This works fine using cmd, I can just type in 'gradle XXX'. However, with rust's 'Command' object (which was being used in cargo-apk), it returns file not found. Attempts to change the name of gradle.bat to gradle were unsuccessful (windows didn't recognise gradle as executable anymore maybe?)

I added a gradle_command field to the android metadata section of the cargo.toml. This lets me put 'gradle.bat' as my gradle command, and the build now passes the gradle check.