### PR TITLE
Add instruction to install CMake to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Before you can compile for Android, you need to setup your environment. This nee
  - Run `rustup target add arm-linux-androideabi`, or any other target that you want to compile to.
 
  - Install the Java JDK (on Ubuntu, `sudo apt-get install openjdk-8-jdk`)
+ - Install CMake (on Ubuntu, `sudo apt-get install cmake`)
  - [Install Gradle](https://gradle.org/install/).
 
  - Download and unzip [the Android NDK](http://developer.android.com/tools/sdk/ndk/index.html)


### PR DESCRIPTION
I had to have CMake installed on my system in order for `cargo install cargo-apk` to work. Without CMake installed, it gave me this error:

error: failed to run custom build command for `libssh2-sys v0.2.6`

Later in the error output, I found:

is `cmake` not installed?

I installed CMake and ran the cargo install command again and everything worked. Hopefully this will save others a little time.