### PR TITLE
Support min/targetSdkVersion specifying

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ assets = "path/to/assets_folder"
 
 # The target Android API level.
 # It defaults to 18 because this is the minimum supported by rustc.
+# (target_sdk_version and min_sdk_version default to the value of "android_version")
 android_version = 18
+target_sdk_version = 18
+min_sdk_version = 18
 
 # If set to true, makes the app run in full-screen, by adding the following line
 # as an XML attribute to the manifest's <application> tag :

--- a/cargo-apk/Cargo.lock
+++ b/cargo-apk/Cargo.lock
@@ -1,13 +1,3 @@
-[root]
-name = "cargo-apk"
-version = "0.3.2"
-dependencies = [
- "cargo 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "advapi32-sys"
 version = "0.2.0"
@@ -99,6 +89,16 @@ dependencies = [
  "toml 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cargo-apk"
+version = "0.4.0"
+dependencies = [
+ "cargo 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/cargo-apk/src/config.rs
+++ b/cargo-apk/src/config.rs
@@ -39,6 +39,10 @@ pub struct AndroidConfig {
 
     /// Version of android for which to compile. TODO: ensure that >=18 because Rustc only supports 18+
     pub android_version: u32,
+    /// Version of android:targetSdkVersion (optional). Default Value = android_version
+    pub target_sdk_version: u32,
+    /// Version of android:minSdkVersion (optional). Default Value = android_version
+    pub min_sdk_version: u32,
 
     /// Version of the build tools to use
     pub build_tools_version: String,
@@ -149,6 +153,11 @@ pub fn load(workspace: &Workspace, flag_package: &Option<String>) -> Result<Andr
         versions.into_iter().next().unwrap_or("26.0.0".to_owned())
     };
 
+    // Determine the Sdk versions (compile, target, min)
+    let android_version = manifest_content.as_ref().and_then(|a| a.android_version).unwrap_or(18);
+    let target_sdk_version = manifest_content.as_ref().and_then(|a| a.target_sdk_version).unwrap_or(android_version);
+    let min_sdk_verision = manifest_content.as_ref().and_then(|a| a.min_sdk_version).unwrap_or(android_version);
+
     // For the moment some fields of the config are dummies.
     Ok(AndroidConfig {
         sdk_path: Path::new(&sdk_path).to_owned(),
@@ -162,7 +171,9 @@ pub fn load(workspace: &Workspace, flag_package: &Option<String>) -> Result<Andr
         package_icon: manifest_content.as_ref().and_then(|a| a.icon.clone()),
         build_targets: manifest_content.as_ref().and_then(|a| a.build_targets.clone())
             .unwrap_or(vec!["arm-linux-androideabi".to_owned()]),
-        android_version: manifest_content.as_ref().and_then(|a| a.android_version).unwrap_or(18),
+        android_version: android_version,
+        target_sdk_version: target_sdk_version,
+        min_sdk_version: min_sdk_verision,
         build_tools_version: build_tools_version,
         assets_path: manifest_content.as_ref().and_then(|a| a.assets.as_ref())
             .map(|p| package.manifest_path().parent().unwrap().join(p)),
@@ -209,6 +220,8 @@ struct TomlAndroid {
     assets: Option<String>,
     res: Option<String>,
     android_version: Option<u32>,
+    target_sdk_version: Option<u32>,
+    min_sdk_version: Option<u32>,
     fullscreen: Option<bool>,
     application_attributes: Option<BTreeMap<String, String>>,
     activity_attributes: Option<BTreeMap<String, String>>,

--- a/cargo-apk/src/ops/build.rs
+++ b/cargo-apk/src/ops/build.rs
@@ -513,6 +513,7 @@ fn build_manifest(_: &Workspace, path: &Path, config: &AndroidConfig) -> Result<
         android:versionCode="1"
         android:versionName="1.0">
 
+    <uses-sdk android:targetSdkVersion="{targetSdkVersion}" />
     <uses-sdk android:minSdkVersion="{minSdkVersion}" />
 
     <uses-feature android:glEsVersion="{glEsVersion}" android:required="true"></uses-feature>
@@ -533,7 +534,8 @@ fn build_manifest(_: &Workspace, path: &Path, config: &AndroidConfig) -> Result<
 <!-- END_INCLUDE(manifest) -->
 "#,
         package = config.package_name.replace("-", "_"),
-        minSdkVersion = config.android_version,
+        targetSdkVersion = config.target_sdk_version,
+        minSdkVersion = config.min_sdk_version,
         glEsVersion = format!("0x{:04}{:04}", config.opengles_version_major, config.opengles_version_minor),
         application_attrs = application_attrs,
         activity_attrs = activity_attrs


### PR DESCRIPTION
This enables to set "target_sdk_version" and "min_sdk_version" in addition to "android_version"(=compilerSdkVersion), like build.gradle.