### PR TITLE
Bump patch version to 0.4.2.

### DIFF
--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-apk"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT"
 description = "Cargo subcommand that allows you to build Android packages"


### PR DESCRIPTION
Bump patch version of cargo-apk so that Docker images are rebuilt.

Should fix #180 and update https://hub.docker.com/r/tomaka/cargo-apk/