### PR TITLE
Allow offline builds

### DIFF
--- a/cargo-apk/src/config.rs
+++ b/cargo-apk/src/config.rs
@@ -19,6 +19,9 @@ pub struct AndroidConfig {
     pub ndk_path: PathBuf,
     /// How to invoke `gradle`.
     pub gradle_command: String,
+    /// Stuff to include in the build.gradle file instead of the hard-coded
+    /// repository information
+    pub build_gradle_inc: Option<PathBuf>,
 
     /// Name that the package will have on the Android machine.
     /// This is the key that Android uses to identify your package, so it should be unique for
@@ -128,6 +131,10 @@ pub fn load(workspace: &Workspace, flag_package: &Option<String>) -> Result<Andr
                     the $ANDROID_HOME environment variable.")
     };
 
+    let build_gradle_inc = env::var("CARGO_APK_BUILD_GRADLE_INC")
+        .ok()
+        .map(|s| PathBuf::from(s));
+
     // Find the highest build tools.
     let build_tools_version = {
         let mut dir = fs::read_dir(Path::new(&sdk_path).join("build-tools"))
@@ -164,6 +171,7 @@ pub fn load(workspace: &Workspace, flag_package: &Option<String>) -> Result<Andr
         sdk_path: Path::new(&sdk_path).to_owned(),
         ndk_path: Path::new(&ndk_path).to_owned(),
         gradle_command: gradle_command,
+        build_gradle_inc: build_gradle_inc,
         package_name: manifest_content.as_ref().and_then(|a| a.package_name.clone())
                                        .unwrap_or_else(|| format!("rust.{}", package_name)),
         project_name: package_name.clone(),

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -40,17 +40,17 @@ fn main() {
     let arg_target_dir = &subcommand_args.value_of_path("target-dir", &cargo_config);
 
     cargo_config.configure(
-        args.occurrences_of("verbose") as u32,
-        if args.is_present("quiet") {
+        subcommand_args.occurrences_of("verbose") as u32,
+        if subcommand_args.is_present("quiet") {
             Some(true)
         } else {
             None
         },
-        &args.value_of("color").map(|s| s.to_string()),
-        args.is_present("frozen"),
-        args.is_present("locked"),
+        &subcommand_args.value_of("color").map(|s| s.to_string()),
+        subcommand_args.is_present("frozen"),
+        subcommand_args.is_present("locked"),
         arg_target_dir,
-        &args.values_of_lossy("unstable-features")
+        &subcommand_args.values_of_lossy("unstable-features")
             .unwrap_or_default(),
     ).unwrap();
 
@@ -119,6 +119,11 @@ fn cli_build() -> App<'static, 'static> {
       .arg_manifest_path()
       .arg_message_format()
       .arg_build_plan()
+      .arg_verbose()
+      .arg_quiet()
+      .arg_color()
+      .arg_frozen()
+      .arg_locked()
       .after_help(
             "\
 All packages in the workspace are built if the `--all` flag is supplied. The
@@ -427,6 +432,29 @@ pub trait AppExt: Sized {
 
     fn arg_build_plan(self) -> Self {
         self._arg(opt("build-plan", "Output the build plan in JSON"))
+    }
+
+    fn arg_verbose(self) -> Self {
+        self._arg(opt("verbose", "Use verbose output")
+                  .short("v"))
+    }
+
+    fn arg_quiet(self) -> Self {
+        self._arg(opt("quiet", "No output printed to stdout")
+                  .short("q"))
+    }
+
+    fn arg_color(self) -> Self {
+        self._arg(opt("color", "Coloring: auto, always, never")
+                  .value_name("WHEN"))
+    }
+
+    fn arg_frozen(self) -> Self {
+        self._arg(opt("frozen", "Require Cargo.lock and cache are up to date"))
+    }
+
+    fn arg_locked(self) -> Self {
+        self._arg(opt("locked", "Require Cargo.lock is up to date"))
     }
 
     fn arg_new_opts(self) -> Self {

--- a/cargo-apk/src/ops/build.rs
+++ b/cargo-apk/src/ops/build.rs
@@ -327,11 +327,15 @@ pub fn build(workspace: &Workspace, config: &AndroidConfig, options: &ArgMatches
     // Invoking `gradle` from within `android-artifacts` in order to compile the project.
     drop(writeln!(workspace.config().shell().err(), "Invoking gradle"));
     let mut cmd = process(&config.gradle_command);
+    if workspace.config().frozen() {
+        cmd.arg("--offline");
+    }
     if config.release {
         cmd.arg("assembleRelease");
     } else {
         cmd.arg("assembleDebug");
     }
+    drop(writeln!(workspace.config().shell().err(), "{}", cmd));
     cmd.cwd(&android_artifacts_dir)
        .exec()?;
 


### PR DESCRIPTION
This builds on top of #205, and allows users of `cargo-apk` to configure the gradle build such that it operates entirely in offline mode. Requires the user to set up a file that replaces the hard-coded jcenter() repository thingy.