### PR TITLE
Make cargo-apk a library.

### DIFF
--- a/cargo-apk/src/lib.rs
+++ b/cargo-apk/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod config;
+pub mod ops;
+
+pub use config::{AndroidBuildTarget, AndroidConfig};
+pub use ops::build::build_apks;
+pub use ops::build::compile::{build_shared_libraries, SharedLibraries, SharedLibrary};
+pub use ops::build::util::BuildTarget;

--- a/cargo-apk/src/ops/build.rs
+++ b/cargo-apk/src/ops/build.rs
@@ -1,11 +1,12 @@
-mod compile;
+pub mod compile;
 mod targets;
 pub mod tempfile;
-mod util;
+pub mod util;
 
 use self::compile::SharedLibraries;
+use self::util::BuildTarget;
 use crate::config::{AndroidConfig, AndroidTargetConfig};
-use cargo::core::{Target, TargetKind, Workspace};
+use cargo::core::{TargetKind, Workspace};
 use cargo::util::process_builder::process;
 use cargo::util::CargoResult;
 use clap::ArgMatches;
@@ -30,11 +31,11 @@ pub fn build(
 ) -> CargoResult<BuildResult> {
     let root_build_dir = util::get_root_build_directory(workspace, config);
     let shared_libraries =
-        compile::build_shared_libraries(workspace, config, options, &root_build_dir)?;
+        compile::build_shared_libraries(workspace, config, options, &root_build_dir, None, &[])?;
     build_apks(config, &root_build_dir, shared_libraries)
 }
 
-fn build_apks(
+pub fn build_apks(
     config: &AndroidConfig,
     root_build_dir: &PathBuf,
     shared_libraries: SharedLibraries,
@@ -238,7 +239,7 @@ fn build_manifest(
     path: &Path,
     config: &AndroidConfig,
     target_config: &AndroidTargetConfig,
-    target: &Target,
+    target: &BuildTarget,
 ) -> CargoResult<()> {
     let file = path.join("AndroidManifest.xml");
     let mut file = File::create(&file)?;

--- a/cargo-apk/src/ops/build/util.rs
+++ b/cargo-apk/src/ops/build/util.rs
@@ -5,6 +5,35 @@ use failure::format_err;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct BuildTarget {
+    name: String,
+    kind: TargetKind,
+}
+
+impl BuildTarget {
+    pub fn new(name: String, kind: TargetKind) -> Self {
+        Self { name, kind }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn kind(&self) -> &TargetKind {
+        &self.kind
+    }
+}
+
+impl From<&Target> for BuildTarget {
+    fn from(target: &Target) -> Self {
+        Self {
+            name: target.name().to_owned(),
+            kind: target.kind().to_owned(),
+        }
+    }
+}
+
 /// Returns the directory in which all cargo apk artifacts for the current
 /// debug/release configuration should be produced.
 pub fn get_root_build_directory(workspace: &Workspace, config: &AndroidConfig) -> PathBuf {
@@ -21,7 +50,10 @@ pub fn get_root_build_directory(workspace: &Workspace, config: &AndroidConfig) -
 }
 
 /// Returns the sub directory within the root build directory for the specified target.
-pub fn get_target_directory(root_build_dir: &PathBuf, target: &Target) -> CargoResult<PathBuf> {
+pub fn get_target_directory(
+    root_build_dir: &PathBuf,
+    target: &BuildTarget,
+) -> CargoResult<PathBuf> {
     let target_directory = match target.kind() {
         TargetKind::Bin => root_build_dir.join("bin"),
         TargetKind::ExampleBin => root_build_dir.join("examples"),

--- a/cargo-apk/src/ops/mod.rs
+++ b/cargo-apk/src/ops/mod.rs
@@ -1,4 +1,4 @@
-mod build;
+pub mod build;
 mod install;
 mod run;
 


### PR DESCRIPTION
Used by `cargo-flutter`.

- Makes a couple of things public
- adds support for passing additional rust flags
- `config::load` function takes a `cargo::core::Package`
- replaces `cargo::core::Target` with `BuildTarget` in `build_apks`